### PR TITLE
Fix problem where unable to run `hexo server`

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,14 +1,14 @@
 {
   "name": "hexo-site",
-  "version": "2.8.2",
+  "version": "2.8.3",
   "private": true,
   "devDependencies": {
     "hexo": "~2.8.2",
     "hexo-deployer-s3": "git://github.com/nt3rp/hexo-deployer-s3.git",
     "hexo-generator-feed": "git://github.com/nt3rp/hexo-generator-feed.git",
     "hexo-generator-sitemap": "~0.2.0",
-    "hexo-renderer-ejs": "*",
-    "hexo-renderer-marked": "*",
-    "hexo-renderer-stylus": "*"
+    "hexo-renderer-ejs": "^0.1.0",
+    "hexo-renderer-marked": "^0.1",
+    "hexo-renderer-stylus": "^0.1"
   }
 }


### PR DESCRIPTION
It seems like Hexo has since upgraded to version 3.x, and our dependencies were unversioned.

Created issue to track 3.x: #23